### PR TITLE
llcppsymg:remove leading underscores

### DIFF
--- a/chore/_xtool/llcppsymg/_cmptest/parse_test/llgo.expect
+++ b/chore/_xtool/llcppsymg/_cmptest/parse_test/llgo.expect
@@ -46,10 +46,10 @@ Before: Class: INIReader, Method: HasValue After: (*Reader).HasValue
 
 === Test Case: C++ Class with Methods ===
 Parsed Symbols:
-Symbol Map GoName: (*Reader).Init__1, ProtoName In HeaderFile: INIReader::INIReader(const char *, int), MangledName: _ZN9INIReaderC1EPKci
-Symbol Map GoName: (*Reader).Init, ProtoName In HeaderFile: INIReader::INIReader(const int &), MangledName: _ZN9INIReaderC1ERKi
-Symbol Map GoName: (*Reader).Dispose, ProtoName In HeaderFile: INIReader::~INIReader(), MangledName: _ZN9INIReaderD1Ev
-Symbol Map GoName: (*Reader).ParseError, ProtoName In HeaderFile: INIReader::ParseError(), MangledName: _ZNK9INIReader10ParseErrorEv
+Symbol Map GoName: (*Reader).Init__1, ProtoName In HeaderFile: INIReader::INIReader(const char *, int), MangledName: ZN9INIReaderC1EPKci
+Symbol Map GoName: (*Reader).Init, ProtoName In HeaderFile: INIReader::INIReader(const int &), MangledName: ZN9INIReaderC1ERKi
+Symbol Map GoName: (*Reader).Dispose, ProtoName In HeaderFile: INIReader::~INIReader(), MangledName: ZN9INIReaderD1Ev
+Symbol Map GoName: (*Reader).ParseError, ProtoName In HeaderFile: INIReader::ParseError(), MangledName: ZNK9INIReader10ParseErrorEv
 
 === Test Case: C Functions ===
 Parsed Symbols:

--- a/chore/_xtool/llcppsymg/_cmptest/symg_test/llgo.expect
+++ b/chore/_xtool/llcppsymg/_cmptest/symg_test/llgo.expect
@@ -1,23 +1,23 @@
 #stdout
 === Test Case: inireader ===
 [{
-		"mangle":	"_ZN9INIReaderC1EPKc",
+		"mangle":	"ZN9INIReaderC1EPKc",
 		"c++":	"INIReader::INIReader(const char *)",
 		"go":	"(*Reader).Init"
 	}, {
-		"mangle":	"_ZN9INIReaderC1EPKcl",
+		"mangle":	"ZN9INIReaderC1EPKcl",
 		"c++":	"INIReader::INIReader(const char *, long)",
 		"go":	"(*Reader).Init__1"
 	}, {
-		"mangle":	"_ZN9INIReaderD1Ev",
+		"mangle":	"ZN9INIReaderD1Ev",
 		"c++":	"INIReader::~INIReader()",
 		"go":	"(*Reader).Dispose"
 	}, {
-		"mangle":	"_ZNK9INIReader10ParseErrorEv",
+		"mangle":	"ZNK9INIReader10ParseErrorEv",
 		"c++":	"INIReader::ParseError()",
-		"go":	"(*Reader).ModifyedParseError"
+		"go":	"(*Reader).ParseError"
 	}, {
-		"mangle":	"_ZNK9INIReader3GetEPKcS1_S1_",
+		"mangle":	"ZNK9INIReader3GetEPKcS1_S1_",
 		"c++":	"INIReader::Get(const char *, const char *, const char *)",
 		"go":	"(*Reader).Get"
 	}]

--- a/chore/_xtool/llcppsymg/parse/parse.go
+++ b/chore/_xtool/llcppsymg/parse/parse.go
@@ -132,10 +132,12 @@ func (p *SymbolProcessor) collectFuncInfo(cursor clang.Cursor) {
 	symbol := cursor.Mangling()
 	defer symbol.Dispose()
 
+	// Remove all leading underscores from C++ symbol names
+	// On Linux, C++ symbols typically have one leading underscore
+	// On macOS, C++ symbols may have two leading underscores
+	// We remove all leading underscores to handle both cases consistently
 	symbolName := c.GoString(symbol.CStr())
-	if len(symbolName) >= 1 && symbolName[0] == '_' {
-		symbolName = symbolName[1:]
-	}
+	symbolName = strings.TrimLeft(symbolName, "_")
 	p.SymbolMap[symbolName] = &SymbolInfo{
 		GoName:    p.genGoName(cursor),
 		ProtoName: p.genProtoName(cursor),

--- a/chore/_xtool/llcppsymg/symbol/symbol.go
+++ b/chore/_xtool/llcppsymg/symbol/symbol.go
@@ -88,7 +88,7 @@ func ParseDylibSymbols(lib string) ([]*nm.Symbol, error) {
 func GetCommonSymbols(dylibSymbols []*nm.Symbol, headerSymbols map[string]*parse.SymbolInfo) []*types.SymbolInfo {
 	var commonSymbols []*types.SymbolInfo
 	for _, dylibSym := range dylibSymbols {
-		symName := strings.TrimPrefix(dylibSym.Name, "_")
+		symName := strings.TrimLeft(dylibSym.Name, "_")
 		if symInfo, ok := headerSymbols[symName]; ok {
 			symbolInfo := &types.SymbolInfo{
 				Mangle: symName,


### PR DESCRIPTION
#84 
由于 Linux 和 macOS 上 C++ 符号的前导下划线数量不同,原先仅仅移除头部第一个下划线会导致在linux下比对失败，所以为了兼容这两种情况，移除所有前导下划线进行兼容