### PR TITLE
llcppsymg:multiple & system dylib path search

### DIFF
--- a/chore/_xtool/llcppsymg/_cmptest/symbol_test/llgo.expect
+++ b/chore/_xtool/llcppsymg/_cmptest/symbol_test/llgo.expect
@@ -1,21 +1,36 @@
 #stdout
-=== Test GenDylibPaths ===
+=== Test ParseLibConfig ===
 Test case: Lua library
 Input: -L/opt/homebrew/lib -llua -lm
-Output: [/opt/homebrew/lib/liblua.dylib /opt/homebrew/lib/libm.dylib]
-
+Paths: [/opt/homebrew/lib]
+Names: [lua m]
 Test case: SQLite library
 Input: -L/opt/homebrew/opt/sqlite/lib -lsqlite3
-Output: [/opt/homebrew/opt/sqlite/lib/libsqlite3.dylib]
-
+Paths: [/opt/homebrew/opt/sqlite/lib]
+Names: [sqlite3]
 Test case: INIReader library
 Input: -L/opt/homebrew/Cellar/inih/58/lib -lINIReader
-Output: [/opt/homebrew/Cellar/inih/58/lib/libINIReader.dylib]
-
+Paths: [/opt/homebrew/Cellar/inih/58/lib]
+Names: [INIReader]
+Test case: Multiple library paths
+Input: -L/opt/homebrew/lib -L/usr/lib -llua
+Paths: [/opt/homebrew/lib /usr/lib]
+Names: [lua]
 Test case: No valid library
 Input: -L/opt/homebrew/lib
-Error: failed to parse pkg-config output: -L/opt/homebrew/lib
-
+Paths: [/opt/homebrew/lib]
+Names: []
+=== Test GenDylibPaths ===
+Test case: existing dylib
+Path libsymb1 is in the expected paths
+Test case: existing dylibs
+Path libsymb1 is in the expected paths
+Path libsymb2 is in the expected paths
+Test case: existint default paths
+Path libsymb1 is in the expected paths
+Path libsymb3 is in the expected paths
+Test case: no existing dylib
+Warning: Some libraries were not found: notexist
 === Test GetCommonSymbols ===
 
 Test Case: Lua symbols

--- a/chore/_xtool/llcppsymg/_cmptest/symbol_test/symbol.go
+++ b/chore/_xtool/llcppsymg/_cmptest/symbol_test/symbol.go
@@ -3,7 +3,10 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"runtime"
 	"sort"
+	"strings"
 
 	"github.com/goplus/llgo/chore/_xtool/llcppsymg/parse"
 	"github.com/goplus/llgo/chore/_xtool/llcppsymg/symbol"
@@ -12,13 +15,14 @@ import (
 )
 
 func main() {
+	TestParseLibConfig()
 	TestGenDylibPaths()
 	TestGetCommonSymbols()
 	TestReadExistingSymbolTable()
 	TestGenSymbolTableData()
 }
-func TestGenDylibPaths() {
-	fmt.Println("=== Test GenDylibPaths ===")
+func TestParseLibConfig() {
+	fmt.Println("=== Test ParseLibConfig ===")
 
 	testCases := []struct {
 		name  string
@@ -37,6 +41,10 @@ func TestGenDylibPaths() {
 			input: "-L/opt/homebrew/Cellar/inih/58/lib -lINIReader",
 		},
 		{
+			name:  "Multiple library paths",
+			input: "-L/opt/homebrew/lib -L/usr/lib -llua",
+		},
+		{
 			name:  "No valid library",
 			input: "-L/opt/homebrew/lib",
 		},
@@ -46,15 +54,118 @@ func TestGenDylibPaths() {
 		fmt.Printf("Test case: %s\n", tc.name)
 		fmt.Printf("Input: %s\n", tc.input)
 
-		result, err := symbol.GenDylibPaths(tc.input)
+		conf := symbol.ParseLibConfig(tc.input)
 
-		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-		} else {
-			fmt.Printf("Output: %v\n", result)
-		}
-		fmt.Println()
+		fmt.Println("Paths:", conf.Paths)
+		fmt.Println("Names:", conf.Names)
 	}
+}
+
+func TestGenDylibPaths() {
+	fmt.Println("=== Test GenDylibPaths ===")
+
+	tempDir := os.TempDir()
+	tempDefaultPath := filepath.Join(tempDir, "symblib")
+	affix := ".dylib"
+	if runtime.GOOS == "linux" {
+		affix = ".so"
+	}
+	err := os.MkdirAll(tempDefaultPath, 0755)
+	if err != nil {
+		fmt.Printf("Failed to create temp default path: %v\n", err)
+		return
+	}
+
+	dylib1 := filepath.Join(tempDir, "libsymb1"+affix)
+	dylib2 := filepath.Join(tempDir, "libsymb2"+affix)
+	defaultDylib3 := filepath.Join(tempDefaultPath, "libsymb3"+affix)
+
+	os.Create(dylib1)
+	os.Create(dylib2)
+	os.Create(defaultDylib3)
+	defer os.Remove(dylib1)
+	defer os.Remove(dylib2)
+	defer os.Remove(defaultDylib3)
+	defer os.Remove(tempDefaultPath)
+
+	testCase := []struct {
+		name         string
+		conf         *symbol.LibConfig
+		defaultPaths []string
+		want         []string
+		wantErr      bool
+	}{
+		{
+			name: "existing dylib",
+			conf: &symbol.LibConfig{
+				Names: []string{"symb1"},
+				Paths: []string{tempDir},
+			},
+			defaultPaths: []string{},
+			want:         []string{dylib1},
+		},
+		{
+			name: "existing dylibs",
+			conf: &symbol.LibConfig{
+				Names: []string{"symb1", "symb2"},
+				Paths: []string{tempDir},
+			},
+			defaultPaths: []string{},
+			want:         []string{dylib1, dylib2},
+		},
+		{
+			name: "existint default paths",
+			conf: &symbol.LibConfig{
+				Names: []string{"symb1", "symb3"},
+				Paths: []string{tempDir},
+			},
+			defaultPaths: []string{tempDefaultPath},
+			want:         []string{dylib1, defaultDylib3},
+		},
+		{
+			name: "no existing dylib",
+			conf: &symbol.LibConfig{
+				Names: []string{"notexist"},
+				Paths: []string{tempDir},
+			},
+			want:    []string{},
+			wantErr: true,
+		},
+	}
+	for _, tc := range testCase {
+		fmt.Printf("Test case: %s\n", tc.name)
+		paths, err := symbol.GenDylibPaths(tc.conf, tc.defaultPaths)
+
+		if tc.wantErr {
+			if err == nil {
+				fmt.Printf("Expected error, but got nil\n")
+			}
+		} else {
+			if err != nil {
+				fmt.Printf("Unexpected error: %v\n", err)
+			}
+			for _, path := range paths {
+				found := false
+				for _, wantPath := range tc.want {
+					if path == wantPath {
+						found = true
+						fileName := filepath.Base(path)
+						if runtime.GOOS == "linux" {
+							fileName = strings.TrimSuffix(fileName, ".so")
+						} else {
+							fileName = strings.TrimSuffix(fileName, ".dylib")
+						}
+						fmt.Printf("Path %s is in the expected paths\n", fileName)
+						break
+					}
+				}
+				if !found {
+					fmt.Printf("Path %s is not in the expected paths\n", path)
+				}
+			}
+		}
+	}
+
 }
 func TestGetCommonSymbols() {
 	fmt.Println("=== Test GetCommonSymbols ===")


### PR DESCRIPTION
https://github.com/goplus/llgo/issues/830



- [ ] wait os.Readdir to search `/etc/ld.so.conf.d` 's subdir

在linux环境和macos上都可以正常通过测试。
但是在linux的实际运行中，调用nm的部分，出现如下抛错，调查发现是由于 `exec.Command` 引起的，在linux上运行 _cmptest/osexec也会出现对应的问题

- [ ] wait exec.Command not panic
```
root@be00d9b1c2c9:~/llgo/chore/_xtool/llcppsymg# llgo run .
parse dylib symbols from config lib:-L/lib/aarch64-linux-gnu -llua5.4
panic: todo: syscall.Faccessat
```