### PR TITLE
llcppsymg:symbol debug log

### DIFF
--- a/chore/_xtool/llcppsymg/_cmptest/symbol_test/llgo.expect
+++ b/chore/_xtool/llcppsymg/_cmptest/symbol_test/llgo.expect
@@ -30,7 +30,6 @@ Test case: existint default paths
 Path libsymb1 is in the expected paths
 Path libsymb3 is in the expected paths
 Test case: no existing dylib
-Warning: Some libraries were not found: notexist
 === Test GetCommonSymbols ===
 
 Test Case: Lua symbols


### PR DESCRIPTION
```bash
root@be00d9b1c2c9:~/llgo/chore/_xtool/llcppsymg# ./llcppsymg -v
Config From File llcppg.cfg
Name: lua
CFlags: -I/usr/include/lua5.4
Libs: -L/lib/aarch64-linux-gnu -llua5.4
Include: [lua.h]
TrimPrefixes: [lua_ lua_]
Cplusplus: false
ParseDylibSymbols:from -L/lib/aarch64-linux-gnu -llua5.4
ParseDylibSymbols:LibConfig Parse To
conf.Names:  [lua5.4]
conf.Paths:  [/lib/aarch64-linux-gnu]
getSysLibPaths:find sys lib path from linux
getPath:from /etc/ld.so.conf
ParseDylibSymbols:dylibPaths [/lib/aarch64-linux-gnu/liblua5.4.so]
panic: todo: syscall.Faccessat
```