### PR TITLE
llgo:build with embed llvm

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,7 +40,13 @@ get_system_info() {
 # Function to install from local source
 install_local() {
     echo "Installing llgo from local source..."
-    go install ./cmd/llgo
+    export CGO_CPPFLAGS="-I/Users/zhangzhiyang/Documents/Code/goplus/llgo/esp-clang/include"
+    export CGO_LDFLAGS="-L/Users/zhangzhiyang/Documents/Code/goplus/llgo/esp-clang/lib -lLLVM"
+    # go install ./cmd/llgo
+
+    go build -o ./build/llgo -tags=byollvm -ldflags="-s -w -X github.com/goplus/llgo/internal/env.buildVersion=v0.12.12 -X github.com/goplus/llgo/internal/env.buildTime=2025-08-26T05:56:44Z -X github.com/goplus/llgo/xtool/env/llvm.ldLLVMConfigBin=/Users/zhangzhiyang/Documents/Code/goplus/llgo/esp-clang/bin/llvm-config" ./cmd/llgo
+
+
     echo "Local installation complete."
     echo "llgo is now available in your GOPATH."
     if [ -n "$GITHUB_ENV" ]; then


### PR DESCRIPTION
got
```bash
llgo on  main [$!?] via 🐹 v1.24.6 
❯ bash ./install.sh
Installing llgo from local source...
# github.com/goplus/llvm
In file included from IRBindings.cpp:13:
In file included from ./IRBindings.h:19:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/IR/Metadata.h:18:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/ArrayRef.h:12:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/Hashing.h:50:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/Support/SwapByteOrder.h:17:
../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/STLForwardCompat.h:46:35: error: no template named 'optional' in namespace 'std'
../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/STLForwardCompat.h:47:13: error: no template named 'optional' in namespace 'std'
../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/STLForwardCompat.h:50:15: error: no member named 'nullopt' in namespace 'std'
../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/STLForwardCompat.h:56:6: error: redefinition of 'transformOptional' as different kind of symbol
../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/STLForwardCompat.h:46:6: note: previous definition is here
../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/STLForwardCompat.h:56:29: error: no member named 'optional' in namespace 'std'
../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/STLForwardCompat.h:56:38: error: 'T' does not refer to a value
../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/STLForwardCompat.h:55:20: note: declared here
../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/STLForwardCompat.h:56:43: error: use of address-of-label extension outside of a function body
../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/STLForwardCompat.h:56:46: error: expected expression
../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/STLForwardCompat.h:56:64: error: expected ';' after top level declarator
In file included from IRBindings.cpp:13:
In file included from ./IRBindings.h:19:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/IR/Metadata.h:18:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/ArrayRef.h:12:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/Hashing.h:50:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/Support/SwapByteOrder.h:18:
../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/bit.h:100:56: error: no template named 'is_integral_v' in namespace 'std'; did you mean 'is_integral'?
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__type_traits/is_integral.h:53:29: note: 'is_integral' declared here
In file included from IRBindings.cpp:13:
In file included from ./IRBindings.h:19:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/IR/Metadata.h:18:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/ArrayRef.h:12:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/Hashing.h:50:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/Support/SwapByteOrder.h:18:
../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/bit.h:100:51: error: template argument for non-type template parameter must be an expression
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__type_traits/enable_if.h:31:16: note: template parameter is declared here
In file included from IRBindings.cpp:13:
In file included from ./IRBindings.h:19:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/IR/Metadata.h:18:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/ArrayRef.h:12:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/Hashing.h:50:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/Support/SwapByteOrder.h:18:
../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/bit.h:102:6: warning: constexpr if is a C++17 extension [-Wc++17-extensions]
../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/bit.h:104:13: warning: constexpr if is a C++17 extension [-Wc++17-extensions]
../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/bit.h:115:13: warning: constexpr if is a C++17 extension [-Wc++17-extensions]
../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/bit.h:128:13: warning: constexpr if is a C++17 extension [-Wc++17-extensions]
../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/bit.h:145:56: error: no template named 'is_unsigned_v' in namespace 'std'; did you mean 'is_unsigned'?
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__type_traits/is_unsigned.h:26:29: note: 'is_unsigned' declared here
In file included from IRBindings.cpp:13:
In file included from ./IRBindings.h:19:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/IR/Metadata.h:18:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/ArrayRef.h:12:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/Hashing.h:50:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/Support/SwapByteOrder.h:18:
../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/bit.h:145:51: error: template argument for non-type template parameter must be an expression
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__type_traits/enable_if.h:31:16: note: template parameter is declared here
In file included from IRBindings.cpp:13:
In file included from ./IRBindings.h:19:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/IR/Metadata.h:18:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/ArrayRef.h:12:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/Hashing.h:50:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/Support/SwapByteOrder.h:18:
../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/bit.h:216:22: error: no template named 'is_unsigned_v' in namespace 'std'; did you mean 'is_unsigned'?
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__type_traits/is_unsigned.h:26:29: note: 'is_unsigned' declared here
In file included from IRBindings.cpp:13:
In file included from ./IRBindings.h:19:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/IR/Metadata.h:18:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/ArrayRef.h:12:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/Hashing.h:50:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/Support/SwapByteOrder.h:18:
../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/bit.h:216:38: error: expected '(' for function-style cast or type construction
../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/bit.h:282:22: error: no template named 'is_unsigned_v' in namespace 'std'; did you mean 'is_unsigned'?
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__type_traits/is_unsigned.h:26:29: note: 'is_unsigned' declared here
In file included from IRBindings.cpp:13:
In file included from ./IRBindings.h:19:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/IR/Metadata.h:18:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/ArrayRef.h:12:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/Hashing.h:50:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/Support/SwapByteOrder.h:18:
../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/bit.h:282:38: error: expected '(' for function-style cast or type construction
../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/bit.h:295:22: error: no template named 'is_unsigned_v' in namespace 'std'; did you mean 'is_unsigned'?
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__type_traits/is_unsigned.h:26:29: note: 'is_unsigned' declared here
In file included from IRBindings.cpp:13:
In file included from ./IRBindings.h:19:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/IR/Metadata.h:18:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/ArrayRef.h:12:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/Hashing.h:50:
In file included from ../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/Support/SwapByteOrder.h:18:
../../../../Documents/Code/goplus/llgo/esp-clang/include/llvm/ADT/bit.h:295:38: error: expected '(' for function-style cast or type construction
fatal error: too many errors emitted, stopping now [-ferror-limit=]
```


```
    export CGO_CPPFLAGS="-I/opt/homebrew/opt/llvm@19/include"
    export CGO_LDFLAGS="-L/opt/homebrew/opt/llvm@19/lib -lLLVM"
    go build -o ./build/llgo -tags=byollvm -ldflags="-s -w -X github.com/goplus/llgo/internal/env.buildVersion=v0.12.12 -X github.com/goplus/llgo/internal/env.buildTime=2025-08-26T05:56:44Z -X github.com/goplus/llgo/xtool/env/llvm.ldLLVMConfigBin=/opt/homebrew/opt/llvm@19/bin/llvm-config" ./cmd/llgo
```
使用llvm@19也会有相同问题。

需要配置

    export CGO_CXXFLAGS="-std=c++17"
